### PR TITLE
Add .ui-btn-active class only to anchor with href

### DIFF
--- a/1.4.3/navigation-hash-processing/index.html
+++ b/1.4.3/navigation-hash-processing/index.html
@@ -38,6 +38,16 @@ $.mobile.document
 
 				data.options.allowSamePageTransition = true;
 		}
+		// Add .ui-btn-active class only to anchor with href
+		// that matches hash
+		if ( $.type( data.absUrl ) !== "undefined" ) {
+			// Remove .ui-btn-active from all anchors wihtin #secondary-page
+			$( "#secondary-page .ui-content .ui-btn-active" )
+			.removeClass( "ui-btn-active" );
+			// Add .ui-btn-active to button with href matching hash
+			$( "#secondary-page" ).find( ".ui-btn[href='" + $.mobile.path.parseUrl(data.absUrl).hash + "']" )
+			.addClass( "ui-btn-active" );
+		}
 	})
 	.on( "pagecontainerbeforetransition", function( event, data ) {
 		var queryParameters = {},


### PR DESCRIPTION
When you navigate several times between sub-pages, all buttons will receive _.ui-btn-active_. This fix removes that class from all buttons and then adds it to button with _href_ matching active page's _hash_.
